### PR TITLE
Sample repro as fat-jar

### DIFF
--- a/sdk/cosmos/azure-cosmos-dotnet-benchmark/pom.xml
+++ b/sdk/cosmos/azure-cosmos-dotnet-benchmark/pom.xml
@@ -410,7 +410,7 @@ Licensed under the MIT License.
                   </descriptorRefs>
                   <archive>
                     <manifest>
-                      <mainClass>com.azure.cosmos.dotnet.benchmark.Main</mainClass>
+                      <mainClass>com.azure.cosmos.dotnet.benchmark.ThinClientReproMain</mainClass>
                     </manifest>
                   </archive>
                 </configuration>

--- a/sdk/cosmos/azure-cosmos-dotnet-benchmark/src/main/java/com/azure/cosmos/dotnet/benchmark/ThinClientReproMain.java
+++ b/sdk/cosmos/azure-cosmos-dotnet-benchmark/src/main/java/com/azure/cosmos/dotnet/benchmark/ThinClientReproMain.java
@@ -1,0 +1,45 @@
+package com.azure.cosmos.dotnet.benchmark;
+
+import com.azure.cosmos.ConsistencyLevel;
+import com.azure.cosmos.CosmosAsyncClient;
+import com.azure.cosmos.CosmosAsyncContainer;
+import com.azure.cosmos.CosmosClientBuilder;
+import com.azure.cosmos.CosmosException;
+import com.azure.cosmos.models.CosmosItemResponse;
+import com.azure.cosmos.models.PartitionKey;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.UUID;
+
+public class ThinClientReproMain {
+    public static void main(String[] args) {
+        try {
+            System.setProperty("COSMOS.THINCLIENT_ENABLED", "true");
+            System.setProperty("COSMOS.HTTP2_ENABLED", "true");
+
+            CosmosAsyncClient client = new CosmosClientBuilder()
+                .key(System.getProperty("COSMOS.KEY"))
+                .endpoint(System.getProperty("COSMOS.ENDPOINT"))
+                .gatewayMode()
+                .consistencyLevel(ConsistencyLevel.SESSION)
+                .buildAsyncClient();
+
+            CosmosAsyncContainer container = client.getDatabase("NehaTestDb").getContainer("NehaTestContainer");
+            ObjectMapper mapper = new ObjectMapper();
+            ObjectNode doc = mapper.createObjectNode();
+            String idValue = UUID.randomUUID().toString();
+            doc.put("id", idValue);
+            System.out.println("Document to be ingested - " + doc.toPrettyString());
+            CosmosItemResponse<ObjectNode> createResponse = container.createItem(doc).block();
+            System.out.println("CREATE DIAGNOSTICS: " + createResponse.getDiagnostics());
+            CosmosItemResponse<ObjectNode> response = container.readItem(idValue, new PartitionKey(idValue), ObjectNode.class).block();
+            System.out.println("READ DIAGNOSTICS: " + response.getDiagnostics());
+            ObjectNode readDoc = response.getItem();
+
+            System.out.println("Document read - " + readDoc.toPrettyString());
+        } catch (CosmosException cosmosException) {
+            System.out.println("COSMOS ERROR: " + cosmosException);
+        }
+    }
+}


### PR DESCRIPTION
Below is the command that can be used to start the repro - ABC is the key

```
java -DCOSMOS.ENDPOINT=https://chukangzhongstagesignoff.documents-staging.windows-ppe.net:443/ -DCOSMOS.KEY=ABC -cp ./azure-cosmos-dotnet-benchmark-4.0.1-beta.1-jar-with-dependencies.jar com.azure.cosmos.dotnet.benchmark.ThinClientReproMain
```

The tool can be compiled by first execurting `mvn -e -DskipTests -Dgpg.skip -Dmaven.javadoc.skip=true -Dcodesnippet.skip=true -Dspotbugs.skip=true -Dcheckstyle.skip=true -Drevapi.skip=true -pl ,azure-cosmos,azure-cosmos-tests -am clean install` from `sdk/cosmos`folder

Then execute `mvn clean package -f pom.xml -DskipTests -Dgpg.skip -Ppackage-assembly` from `sdk/cosmos/azure-cosmos-dotnet-benchmark` folder - the fat-jar will be in the target folder